### PR TITLE
Prod edits

### DIFF
--- a/picturae_csv_create.py
+++ b/picturae_csv_create.py
@@ -6,8 +6,6 @@
 import argparse
 import csv
 import os.path
-
-import pandas as pd
 from taxon_parse_utils import *
 from gen_import_utils import *
 from string_utils import *
@@ -863,7 +861,7 @@ class CsvCreatePicturae:
             raise IncorrectTaxonError(f'TNRS has rejected taxonomic names at '
                                       f'the following batches: {taxon_correct_table}')
 
-    def read_and_clean_image_manifest(self):
+    def read_and_merge_image_manifest(self):
         """to keep taxonomic family consistent with herbarium cabinet order,
             merges the family number from the picturae imaging manifests.
             Herbarium cabinet family number supersedes 'correct' family assignment.
@@ -873,15 +871,24 @@ class CsvCreatePicturae:
         full_manifest = pd.DataFrame(columns=headers)
         # reads and concatenates each imaging manifest from the path
         for batch in batch_list:
-            path_to_csv = f"{self.path_prefix}{path.sep}{batch}{path.sep}{batch}.csv"
+            path_to_csv = f"{self.path_prefix}{batch}{path.sep}{batch}.csv"
             batch_manifest = pd.read_csv(path_to_csv, names=headers)
             full_manifest = pd.concat([full_manifest, batch_manifest], ignore_index=True)
 
-        full_manifest = full_manifest.loc[full_manifest['type'] == 'folder']
-        # keeping only
-        full_manifest.drop(columns=["type", "CatalogNumber", "Barcode", "Timestamp", "Path"])
+        full_manifest = full_manifest.loc[full_manifest['type'].str.lower() == 'folder'.lower()]
+        # keeping only family and cover barcode to merge
+        full_manifest.drop(columns=["type", "CatalogNumber", "Barcode", "Timestamp", "Path"], inplace=True)
 
-        return full_manifest
+        self.record_full = pd.merge(self.record_full, full_manifest, on="folder_barcode")
+
+        # adding boolean column for rows where manifest family number differs from accepted family
+        self.record_full['family_diff'] = self.record_full['Family_x'] != self.record_full['Family_y']
+
+        self.record_full['Family_x'] = self.record_full['Family_y']
+
+        self.record_full.drop(columns="Family_y", inplace=True)
+
+        self.record_full.rename(columns={"Family_x": "Family"}, inplace=True)
 
 
 
@@ -890,10 +897,8 @@ class CsvCreatePicturae:
         """write_upload_csv: writes a copy of csv to PIC upload
             allows for manual review before uploading.
         """
-        # normalizing family number
-        full_manifest = self.read_and_clean_image_manifest()
 
-        self.record_full = pd.merge(self.record_full, full_manifest, on="folder_barcode")
+        self.read_and_merge_image_manifest()
 
         self.record_full.drop(columns=['mostly_handwritten', 'folder_barcode', 'start_date_month',
                                        'start_date_day', 'start_date_year', 'end_date_month',


### PR DESCRIPTION
files changed:
picturae_csv_create.py: now merges in image manifest from delivery folders. Image manifest is used as default so that database family aligns with the family number on the folder regardless of taxonomic acceptance, so that it aligns with its cabinet. This will be useful for the more neglected parts of the collection when we move onto the rest of the world.
+ creates a boolean flag to go back and check if any rows differed from their folder numbers.